### PR TITLE
Merge develop into main for trunk-based migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-﻿# Welcome to Hyperbee Expressions
+# Welcome to Hyperbee Expressions
 
-`Hyperbee.Expressions` is a library for creating c# expression trees that extend the capabilities of standard expression 
-trees to handle asynchronous workflows and other language constructs.
+This repository contains libraries for extending and compiling C# expression trees.
 
-## Features
+## Packages
+
+| Package | Description |
+| ------- | ----------- |
+| **Hyperbee.Expressions** | Extended expression tree nodes for async workflows, iterators, resource management, and looping constructs. |
+| **Hyperbee.Expressions.Compiler** | A high-performance, IR-based expression compiler that is 9-34x faster than the System compiler with correct IL across all expression tree patterns. |
+
+## Hyperbee.Expressions
+
+`Hyperbee.Expressions` extends the capabilities of standard expression trees to handle asynchronous workflows and other 
+language constructs.
+
+### Features
 
 * **Async Expressions**
     * `AwaitExpression`: An expression that represents an await operation.
@@ -35,9 +46,9 @@ trees to handle asynchronous workflows and other language constructs.
     var interpetedLambda = lambda.Compile(preferInterpretation: true);
     ```
 
-## Examples
+### Examples
 
-### Asynchronous Expressions
+#### Asynchronous Expressions
 
 The following example demonstrates how to create an asynchronous expression tree.
 
@@ -87,7 +98,7 @@ public class Example
 }
 ```
 
-### Yield Expressions
+#### Yield Expressions
 
 The following example demonstrates how to create a yield expression tree.
 
@@ -122,7 +133,7 @@ public class Example
 }
 ```
 
-### Using Expression
+#### Using Expression
 
 The following example demonstrates how to create a Using expression.
 
@@ -156,6 +167,34 @@ public class Example
 }
 ```
 
+## Hyperbee.Expressions.Compiler
+
+A high-performance, IR-based expression compiler for .NET. Drop-in replacement for `Expression.Compile()` 
+that is **9-34x faster and allocates up to 50% less than the System compiler** and supports **all expression 
+tree patterns** -- including those that [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler) doesn't.
+
+### Quick Start
+
+```
+dotnet add package Hyperbee.Expressions.Compiler
+```
+
+```csharp
+using Hyperbee.Expressions.Compiler;
+
+// Direct compilation -- drop-in replacement for Expression.Compile()
+var lambda = Expression.Lambda<Func<int, int, int>>(
+    Expression.Add( a, b ), a, b );
+
+var fn = HyperbeeCompiler.Compile( lambda );
+var result = fn( 1, 2 ); // 3
+
+// Or use the extension method
+var fn = lambda.CompileHyperbee();
+```
+
+For benchmarks, architecture details, and advanced usage, see the full [Hyperbee.Expressions.Compiler README](src/Hyperbee.Expressions.Compiler/README.md).
+
 ## Credits
 
 Special thanks to:
@@ -168,4 +207,3 @@ Special thanks to:
 
 We welcome contributions! Please see our [Contributing Guide](https://github.com/Stillpoint-Software/.github/blob/main/.github/CONTRIBUTING.md) 
 for more details
-

--- a/src/Hyperbee.Expressions.Compiler/README.md
+++ b/src/Hyperbee.Expressions.Compiler/README.md
@@ -1,12 +1,11 @@
 # Hyperbee Expression Compiler
 
 A high-performance, IR-based expression compiler for .NET. Drop-in replacement for `Expression.Compile()`
-that is **9-34x faster and allocates up to 50% less than the System compiler** and supports **all expression tree patterns** — including
-those that [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler) doesn't.
+that is **9-34x faster and allocates up to 50% less than the System compiler** and supports **all expression tree patterns**.
 
 ## Why Another Expression Compiler?
 
-We :heart: [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler). FEC is faster than Hyperbee Expression Compiler, and allocates less memory — and for many workloads it's the right choice. If FEC compiles your expressions correctly, use it.
+We :heart: [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler). FEC is faster than Hyperbee Expression Compiler, and allocates less memory - and for many workloads it's the right choice.
 
 FEC's single-pass, low allocation, IL emission approach supports most, but not **all**, expression patterns. See [FEC issues](https://github.com/dadhi/FastExpressionCompiler/issues); patterns like compound assignments inside `TryCatch`, complex closure captures, and certain value-type operations aren't supported.
 
@@ -14,7 +13,7 @@ Hyperbee takes a middle ground: a **multi-pass IR pipeline** that lowers express
 
 ## Performance
 
-HEC is consistently **9-34x faster than the System Compiler** and within **1.16-1.54x of FEC** across all tiers — while producing correct IL for the sub-set of patterns FEC doesn't support (`NegateChecked` overflow, `NaN` comparisons, value-type instance calls, compound assignments in `TryCatch`, etc.).
+HEC is consistently **9-34x faster than the System Compiler** and within **1.16-1.54x of FEC** across all tiers - while producing correct IL for the sub-set of patterns FEC doesn't support (`NegateChecked` overflow, `NaN` comparisons, value-type instance calls, compound assignments in `TryCatch`, etc.).
 
 The Complex tier standout (~34x vs System) is where the multi-pass IR architecture pays off against the System compiler's heavyweight compilation pipeline. The Switch tier at 1.54x is the widest gap vs FEC.
 
@@ -23,34 +22,34 @@ The Complex tier standout (~34x vs System) is where the multi-pass IR architectu
 ```
 BenchmarkDotNet v0.15.8, Windows 11
 Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
-.NET SDK 10.0.103 — .NET 9.0.12, X64 RyuJIT x86-64-v3
+.NET SDK 10.0.103 - .NET 9.0.12, X64 RyuJIT x86-64-v3
 ```
 
 | Tier         | Compiler     |        Mean |   Allocated | vs System (speed) | vs FEC (speed) |
 | ------------ | ------------ | ----------: | ----------: | ----------------: | -------------: |
-| **Simple**   | System       |    30.65 us |     4,335 B |                 — |              — |
-|              | FEC          |     2.96 us |       904 B |      10.3x faster |              — |
+| **Simple**   | System       |    30.65 us |     4,335 B |                 - |              - |
+|              | FEC          |     2.96 us |       904 B |      10.3x faster |              - |
 |              | **Hyperbee** | **3.50 us** | **2,176 B** |   **8.8x faster** |      **1.18x** |
-| **Closure**  | System       |    28.55 us |     4,279 B |                 — |              — |
-|              | FEC          |     2.79 us |       895 B |      10.2x faster |              — |
+| **Closure**  | System       |    28.55 us |     4,279 B |                 - |              - |
+|              | FEC          |     2.79 us |       895 B |      10.2x faster |              - |
 |              | **Hyperbee** | **3.24 us** | **2,160 B** |   **8.8x faster** |      **1.16x** |
-| **TryCatch** | System       |    49.59 us |     5,893 B |                 — |              — |
-|              | FEC          |     3.78 us |     1,518 B |      13.1x faster |              — |
+| **TryCatch** | System       |    49.59 us |     5,893 B |                 - |              - |
+|              | FEC          |     3.78 us |     1,518 B |      13.1x faster |              - |
 |              | **Hyperbee** | **5.54 us** | **4,023 B** |   **9.0x faster** |      **1.47x** |
-| **Complex**  | System       |   150.71 us |     4,741 B |                 — |              — |
-|              | FEC          |     3.51 us |     1,392 B |      42.9x faster |              — |
+| **Complex**  | System       |   150.71 us |     4,741 B |                 - |              - |
+|              | FEC          |     3.51 us |     1,392 B |      42.9x faster |              - |
 |              | **Hyperbee** | **4.47 us** | **2,536 B** |  **33.7x faster** |      **1.27x** |
-| **Loop**     | System       |    65.29 us |     6,710 B |                 — |              — |
-|              | FEC          |     4.21 us |     1,110 B |      15.5x faster |              — |
+| **Loop**     | System       |    65.29 us |     6,710 B |                 - |              - |
+|              | FEC          |     4.21 us |     1,110 B |      15.5x faster |              - |
 |              | **Hyperbee** | **5.77 us** | **4,855 B** |  **11.3x faster** |      **1.37x** |
-| **Switch**   | System       |    61.83 us |     6,264 B |                 — |              — |
-|              | FEC          |     3.61 us |     1,352 B |      17.1x faster |              — |
+| **Switch**   | System       |    61.83 us |     6,264 B |                 - |              - |
+|              | FEC          |     3.61 us |     1,352 B |      17.1x faster |              - |
 |              | **Hyperbee** | **5.55 us** | **4,152 B** |  **11.2x faster** |      **1.54x** |
 
 ### Allocation Profile
 
 The multi-pass IR pipeline allocates roughly **1.8–4.4× more than FEC** per compilation call but
-**up to 50% less than the System Compiler**. The overhead is per-compilation, not per-execution —
+**up to 50% less than the System Compiler**. The overhead is per-compilation, not per-execution -
 compiled delegates run at equivalent speed regardless of which compiler produced them. For hot paths
 that compile once and cache, the allocation difference is negligible. For workloads that re-compile
 frequently (dynamic LINQ providers, interpreted rule engines), prefer FEC when its patterns cover your
@@ -59,7 +58,7 @@ use case.
 ### Execution Benchmarks
 
 All three compilers produce delegates with equivalent runtime performance. For non-trivial expressions
-(Complex, Loop), the difference is zero — the compiled IL is structurally identical. For trivial
+(Complex, Loop), the difference is zero - the compiled IL is structurally identical. For trivial
 expressions (Simple, Switch), sub-nanosecond differences reflect JIT inlining decisions around
 `DynamicMethod` boundaries, not meaningful execution overhead.
 
@@ -68,22 +67,22 @@ expressions (Simple, Switch), sub-nanosecond differences reflect JIT inlining de
 
 | Tier         | Compiler     |     Mean | vs System |
 | ------------ | ------------ | -------: | --------: |
-| **Simple**   | System       | 1.098 ns |         — |
+| **Simple**   | System       | 1.098 ns |         - |
 |              | FEC          | 1.363 ns |     1.24x |
 |              | **Hyperbee** | 1.769 ns |     1.61x |
-| **Closure**  | System       | 0.387 ns |         — |
+| **Closure**  | System       | 0.387 ns |         - |
 |              | FEC          | 0.996 ns |     2.58x |
 |              | **Hyperbee** | 1.520 ns |     3.93x |
-| **TryCatch** | System       | 0.447 ns |         — |
+| **TryCatch** | System       | 0.447 ns |         - |
 |              | FEC          | 1.074 ns |     2.40x |
 |              | **Hyperbee** | 1.731 ns |     3.87x |
-| **Complex**  | System       | 25.42 ns |         — |
+| **Complex**  | System       | 25.42 ns |         - |
 |              | FEC          | 25.22 ns |   **~1x** |
 |              | **Hyperbee** | 24.81 ns |   **~1x** |
-| **Loop**     | System       | 30.62 ns |         — |
+| **Loop**     | System       | 30.62 ns |         - |
 |              | FEC          |      N/A |       N/A |
 |              | **Hyperbee** | 31.76 ns |   **~1x** |
-| **Switch**   | System       |  1.57 ns |         — |
+| **Switch**   | System       |  1.57 ns |         - |
 |              | FEC          |  1.87 ns |     1.20x |
 |              | **Hyperbee** |  2.23 ns |     1.42x |
 
@@ -119,7 +118,7 @@ dotnet add package Hyperbee.Expressions.Compiler
 ```csharp
 using Hyperbee.Expressions.Compiler;
 
-// Direct compilation — drop-in replacement for Expression.Compile()
+// Direct compilation - drop-in replacement for Expression.Compile()
 var lambda = Expression.Lambda<Func<int, int, int>>(
     Expression.Add( a, b ), a, b );
 
@@ -147,7 +146,7 @@ var fn = HyperbeeCompiler.CompileWithFallback( lambda );
 
 ### Compile to MethodBuilder
 
-Emit the expression tree directly into a static `MethodBuilder` on a dynamic type — useful when building
+Emit the expression tree directly into a static `MethodBuilder` on a dynamic type - useful when building
 assemblies with `AssemblyBuilder`/`TypeBuilder`. Only expressions with embeddable constants (no closures
 over heap objects) are supported; use `TryCompileToMethod` for a non-throwing variant.
 
@@ -196,7 +195,7 @@ Expression Tree
 | **StackSpillPass** | Ensures stack is empty at exception handling boundaries (CLR requirement)            |
 | **PeepholePass**   | Removes redundant load/store pairs, dead loads, identity box/unbox roundtrips        |
 | **DeadCodePass**   | Eliminates unreachable instructions after unconditional control transfers            |
-| **IRValidator**    | Structural validation — stack depth, label references, exception blocks (DEBUG only) |
+| **IRValidator**    | Structural validation - stack depth, label references, exception blocks (DEBUG only) |
 
 ## Supported Frameworks
 
@@ -206,10 +205,10 @@ Expression Tree
 
 ## Credits
 
-- [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler) by Maksim Volkau —
+- [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler) by Maksim Volkau -
   the inspiration and benchmark target. FEC pioneered high-performance expression compilation
   and remains the fastest option available. :heart:
-- [System.Linq.Expressions](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions) —
+- [System.Linq.Expressions](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions) -
   the reference implementation and correctness baseline.
 
 ## License

--- a/test/Hyperbee.Expressions.Compiler.Benchmarks/BenchmarkColumns.cs
+++ b/test/Hyperbee.Expressions.Compiler.Benchmarks/BenchmarkColumns.cs
@@ -1,4 +1,4 @@
-using BenchmarkDotNet.Columns;
+﻿using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 
@@ -8,7 +8,7 @@ namespace Hyperbee.Expressions.Compiler.Benchmarks;
 /// Custom BenchmarkDotNet column that shows the ratio of this benchmark's time or
 /// per-operation allocation versus a named compiler baseline, matched by method name suffix.
 ///
-/// Example: for baselineSuffix "_System", "Loop_Hyperbee" is compared to "Loop_System"
+/// Example: For baselineSuffix "_System", "Loop_Hyperbee" is compared to "Loop_System"
 /// within the same benchmark class, giving a clean "vs System" ratio per tier.
 /// </summary>
 public sealed class RatioToColumn : IColumn


### PR DESCRIPTION
Part of org-wide trunk-based migration. develop has been caught up with main (merge conflict in README resolved in favor of main's wording).

develop SHA for rollback: d6b1754